### PR TITLE
티어 지도 바텀 시트 구현

### DIFF
--- a/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
+++ b/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		5826A1E52C75FE9C0097256C /* TierMapBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */; };
 		5826A1E72C77197F0097256C /* NMFMapMarkerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */; };
 		5826A1E92C77230A0097256C /* NMFMapPolygonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */; };
+		5826A1EB2C77267D0097256C /* NMFMapCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1EA2C77267D0097256C /* NMFMapCameraManager.swift */; };
 		5841731D2C46425C001EC132 /* HomeRestaurantLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */; };
 		584173202C464695001EC132 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731F2C464695001EC132 /* HomeViewController.swift */; };
 		584173272C464FFB001EC132 /* TabBarFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */; };
@@ -247,6 +248,7 @@
 		5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierMapBottomSheet.swift; sourceTree = "<group>"; };
 		5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapMarkerManager.swift; sourceTree = "<group>"; };
 		5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapPolygonManager.swift; sourceTree = "<group>"; };
+		5826A1EA2C77267D0097256C /* NMFMapCameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapCameraManager.swift; sourceTree = "<group>"; };
 		5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRestaurantLists.swift; sourceTree = "<group>"; };
 		5841731F2C464695001EC132 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarFlowCoordinator.swift; sourceTree = "<group>"; };
@@ -791,6 +793,7 @@
 				584FA4D12C6487C4008DDC19 /* NMFMapViewHandler.swift */,
 				5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */,
 				5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */,
+				5826A1EA2C77267D0097256C /* NMFMapCameraManager.swift */,
 			);
 			path = TierMap;
 			sourceTree = "<group>";
@@ -1479,6 +1482,7 @@
 				584FA4CB2C6475C7008DDC19 /* TierMapRepository.swift in Sources */,
 				5826A1E92C77230A0097256C /* NMFMapPolygonManager.swift in Sources */,
 				BA57C7BA2C72F1780063F2FA /* AuthRepository.swift in Sources */,
+				5826A1EB2C77267D0097256C /* NMFMapCameraManager.swift in Sources */,
 				58067CAC2C4FB72C00889C92 /* TierListView.swift in Sources */,
 				5841734F2C4682C8001EC132 /* CommunitySceneDIContainer.swift in Sources */,
 				584173492C468250001EC132 /* CommunityFlowCoordinator.swift in Sources */,

--- a/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
+++ b/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		5826A1E22C723BF80097256C /* TierCategoryReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E12C723BF80097256C /* TierCategoryReceivable.swift */; };
 		5826A1E52C75FE9C0097256C /* TierMapBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */; };
 		5826A1E72C77197F0097256C /* NMFMapMarkerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */; };
+		5826A1E92C77230A0097256C /* NMFMapPolygonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */; };
 		5841731D2C46425C001EC132 /* HomeRestaurantLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */; };
 		584173202C464695001EC132 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731F2C464695001EC132 /* HomeViewController.swift */; };
 		584173272C464FFB001EC132 /* TabBarFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */; };
@@ -245,6 +246,7 @@
 		5826A1E12C723BF80097256C /* TierCategoryReceivable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierCategoryReceivable.swift; sourceTree = "<group>"; };
 		5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierMapBottomSheet.swift; sourceTree = "<group>"; };
 		5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapMarkerManager.swift; sourceTree = "<group>"; };
+		5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapPolygonManager.swift; sourceTree = "<group>"; };
 		5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRestaurantLists.swift; sourceTree = "<group>"; };
 		5841731F2C464695001EC132 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarFlowCoordinator.swift; sourceTree = "<group>"; };
@@ -788,6 +790,7 @@
 				5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */,
 				584FA4D12C6487C4008DDC19 /* NMFMapViewHandler.swift */,
 				5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */,
+				5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */,
 			);
 			path = TierMap;
 			sourceTree = "<group>";
@@ -1474,6 +1477,7 @@
 				584173522C4683E3001EC132 /* MyPageViewController.swift in Sources */,
 				584173422C467E72001EC132 /* TierFlowCoordinator.swift in Sources */,
 				584FA4CB2C6475C7008DDC19 /* TierMapRepository.swift in Sources */,
+				5826A1E92C77230A0097256C /* NMFMapPolygonManager.swift in Sources */,
 				BA57C7BA2C72F1780063F2FA /* AuthRepository.swift in Sources */,
 				58067CAC2C4FB72C00889C92 /* TierListView.swift in Sources */,
 				5841734F2C4682C8001EC132 /* CommunitySceneDIContainer.swift in Sources */,

--- a/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
+++ b/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		5826A1DA2C7231880097256C /* TierBaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1D92C7231880097256C /* TierBaseViewModel.swift */; };
 		5826A1E22C723BF80097256C /* TierCategoryReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E12C723BF80097256C /* TierCategoryReceivable.swift */; };
 		5826A1E52C75FE9C0097256C /* TierMapBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */; };
+		5826A1E72C77197F0097256C /* NMFMapMarkerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */; };
 		5841731D2C46425C001EC132 /* HomeRestaurantLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */; };
 		584173202C464695001EC132 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731F2C464695001EC132 /* HomeViewController.swift */; };
 		584173272C464FFB001EC132 /* TabBarFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */; };
@@ -243,6 +244,7 @@
 		5826A1D92C7231880097256C /* TierBaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierBaseViewModel.swift; sourceTree = "<group>"; };
 		5826A1E12C723BF80097256C /* TierCategoryReceivable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierCategoryReceivable.swift; sourceTree = "<group>"; };
 		5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierMapBottomSheet.swift; sourceTree = "<group>"; };
+		5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapMarkerManager.swift; sourceTree = "<group>"; };
 		5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRestaurantLists.swift; sourceTree = "<group>"; };
 		5841731F2C464695001EC132 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarFlowCoordinator.swift; sourceTree = "<group>"; };
@@ -785,6 +787,7 @@
 				584FA4C82C647442008DDC19 /* TierMapView.swift */,
 				5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */,
 				584FA4D12C6487C4008DDC19 /* NMFMapViewHandler.swift */,
+				5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */,
 			);
 			path = TierMap;
 			sourceTree = "<group>";
@@ -1314,6 +1317,7 @@
 				BAC55ECB2C6FA29B00B3078F /* NaverLoginRepository.swift in Sources */,
 				58067D972C61DA3400889C92 /* HomeCategoriesCollectionViewHandler.swift in Sources */,
 				BA37E0872C675FF40092115B /* UIStackView+AutoLayout.swift in Sources */,
+				5826A1E72C77197F0097256C /* NMFMapMarkerManager.swift in Sources */,
 				BA37E07B2C65E5F10092115B /* DrawCollectionViewSection.swift in Sources */,
 				BA57C7BC2C7306340063F2FA /* DefaultAuthRepository.swift in Sources */,
 				BAB69ACB2C71DE3400C20F0B /* DefaultSocialLoginUserRepository.swift in Sources */,

--- a/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
+++ b/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		5826A1E72C77197F0097256C /* NMFMapMarkerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */; };
 		5826A1E92C77230A0097256C /* NMFMapPolygonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */; };
 		5826A1EB2C77267D0097256C /* NMFMapCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1EA2C77267D0097256C /* NMFMapCameraManager.swift */; };
+		5826A1ED2C772C4B0097256C /* TierMapBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1EC2C772C4B0097256C /* TierMapBottomSheetView.swift */; };
 		5841731D2C46425C001EC132 /* HomeRestaurantLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */; };
 		584173202C464695001EC132 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731F2C464695001EC132 /* HomeViewController.swift */; };
 		584173272C464FFB001EC132 /* TabBarFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */; };
@@ -249,6 +250,7 @@
 		5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapMarkerManager.swift; sourceTree = "<group>"; };
 		5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapPolygonManager.swift; sourceTree = "<group>"; };
 		5826A1EA2C77267D0097256C /* NMFMapCameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NMFMapCameraManager.swift; sourceTree = "<group>"; };
+		5826A1EC2C772C4B0097256C /* TierMapBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierMapBottomSheetView.swift; sourceTree = "<group>"; };
 		5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRestaurantLists.swift; sourceTree = "<group>"; };
 		5841731F2C464695001EC132 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarFlowCoordinator.swift; sourceTree = "<group>"; };
@@ -790,6 +792,7 @@
 			children = (
 				584FA4C82C647442008DDC19 /* TierMapView.swift */,
 				5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */,
+				5826A1EC2C772C4B0097256C /* TierMapBottomSheetView.swift */,
 				584FA4D12C6487C4008DDC19 /* NMFMapViewHandler.swift */,
 				5826A1E62C77197F0097256C /* NMFMapMarkerManager.swift */,
 				5826A1E82C77230A0097256C /* NMFMapPolygonManager.swift */,
@@ -1316,6 +1319,7 @@
 				58067D482C5A027000889C92 /* TierCategoryCollectionViewHandler.swift in Sources */,
 				584173642C4791B0001EC132 /* HomeRestaurantsSection.swift in Sources */,
 				BA8EEF8D2C6351D800FE6ABF /* KuPageControl.swift in Sources */,
+				5826A1ED2C772C4B0097256C /* TierMapBottomSheetView.swift in Sources */,
 				584173642C4791B0001EC132 /* HomeRestaurantsSection.swift in Sources */,
 				584173982C4A07DC001EC132 /* UIFont+Pretendard.swift in Sources */,
 				58D83AFD2C463AE200511AB9 /* Restaurant.swift in Sources */,

--- a/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
+++ b/Kustaurant/Kustaurant.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		5826A1D82C7231060097256C /* TierBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1D72C7231060097256C /* TierBaseView.swift */; };
 		5826A1DA2C7231880097256C /* TierBaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1D92C7231880097256C /* TierBaseViewModel.swift */; };
 		5826A1E22C723BF80097256C /* TierCategoryReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E12C723BF80097256C /* TierCategoryReceivable.swift */; };
+		5826A1E52C75FE9C0097256C /* TierMapBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */; };
 		5841731D2C46425C001EC132 /* HomeRestaurantLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */; };
 		584173202C464695001EC132 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5841731F2C464695001EC132 /* HomeViewController.swift */; };
 		584173272C464FFB001EC132 /* TabBarFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */; };
@@ -241,6 +242,7 @@
 		5826A1D72C7231060097256C /* TierBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierBaseView.swift; sourceTree = "<group>"; };
 		5826A1D92C7231880097256C /* TierBaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierBaseViewModel.swift; sourceTree = "<group>"; };
 		5826A1E12C723BF80097256C /* TierCategoryReceivable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierCategoryReceivable.swift; sourceTree = "<group>"; };
+		5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TierMapBottomSheet.swift; sourceTree = "<group>"; };
 		5841731C2C46425C001EC132 /* HomeRestaurantLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRestaurantLists.swift; sourceTree = "<group>"; };
 		5841731F2C464695001EC132 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		584173262C464FFB001EC132 /* TabBarFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarFlowCoordinator.swift; sourceTree = "<group>"; };
@@ -781,6 +783,7 @@
 			isa = PBXGroup;
 			children = (
 				584FA4C82C647442008DDC19 /* TierMapView.swift */,
+				5826A1E42C75FE9C0097256C /* TierMapBottomSheet.swift */,
 				584FA4D12C6487C4008DDC19 /* NMFMapViewHandler.swift */,
 			);
 			path = TierMap;
@@ -1421,6 +1424,7 @@
 				58067D452C59FA6700889C92 /* TierCategoryView.swift in Sources */,
 				CFE2046E2C5E68C500BCA87C /* KuTabBarCollectionView.swift in Sources */,
 				584173812C48C967001EC132 /* HomeRestaurantsCollectionViewCell.swift in Sources */,
+				5826A1E52C75FE9C0097256C /* TierMapBottomSheet.swift in Sources */,
 				5826A1D62C72309B0097256C /* TierTopCategoriesCollectionViewHandler.swift in Sources */,
 				BA37E0B72C6B0A870092115B /* DrawRepository.swift in Sources */,
 				BA8EEF992C64994F00FE6ABF /* LoginView.swift in Sources */,

--- a/Kustaurant/Kustaurant/Application/DIContainer/TierSceneDIContainer.swift
+++ b/Kustaurant/Kustaurant/Application/DIContainer/TierSceneDIContainer.swift
@@ -105,6 +105,10 @@ final class TierSceneDIContainer: TierFlowCoordinatorDependencies {
         )
     }
     
+    func makeTierMapBottomSheet() -> TierMapBottomSheet {
+        TierMapBottomSheet()
+    }
+    
     func makeTierViewController(
         listActions: TierListViewModelActions,
         mapActions: TierMapViewModelActions,

--- a/Kustaurant/Kustaurant/Presentation/Flows/TierFlowCoordinator.swift
+++ b/Kustaurant/Kustaurant/Presentation/Flows/TierFlowCoordinator.swift
@@ -69,9 +69,13 @@ extension TierFlowCoordinator {
         }
     }
     
-    private func showMapBottomSheet() {
-        guard tierMapBottomSheet == nil else { return }
+    private func showMapBottomSheet(restaurant: Restaurant) {
+        guard tierMapBottomSheet == nil else {
+            tierMapBottomSheet?.configure(with: restaurant)
+            return
+        }
         let viewController = dependencies.makeTierMapBottomSheet()
+        viewController.configure(with: restaurant)
         tierMapBottomSheet = viewController
         navigationController.present(viewController, animated: true)
     }

--- a/Kustaurant/Kustaurant/Presentation/Flows/TierFlowCoordinator.swift
+++ b/Kustaurant/Kustaurant/Presentation/Flows/TierFlowCoordinator.swift
@@ -76,6 +76,11 @@ extension TierFlowCoordinator {
         }
         let viewController = dependencies.makeTierMapBottomSheet()
         viewController.configure(with: restaurant)
+        
+        if let mapViewController = getMapViewController() {
+            viewController.delegate = mapViewController
+        }
+        
         tierMapBottomSheet = viewController
         navigationController.present(viewController, animated: true)
     }
@@ -85,4 +90,10 @@ extension TierFlowCoordinator {
         tierMapBottomSheet = nil
     }
     
+}
+
+extension TierFlowCoordinator {
+    private func getMapViewController() -> TierMapViewController? {
+        tierViewController?.viewControllers?.compactMap { $0 as? TierMapViewController }.first
+    }
 }

--- a/Kustaurant/Kustaurant/Presentation/Flows/TierFlowCoordinator.swift
+++ b/Kustaurant/Kustaurant/Presentation/Flows/TierFlowCoordinator.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol TierFlowCoordinatorDependencies {
     func makeTierViewController(listActions: TierListViewModelActions, mapActions: TierMapViewModelActions, initialCategories: [Category]) -> TierViewController
     func makeTierCategoryViewController(actions: TierCategoryViewModelActions, categories: [Category]) -> TierCategoryViewController
+    func makeTierMapBottomSheet() -> TierMapBottomSheet
 }
 
 final class TierFlowCoordinator: Coordinator {
@@ -18,6 +19,7 @@ final class TierFlowCoordinator: Coordinator {
     var navigationController: UINavigationController
 
     private weak var tierViewController: TierViewController?
+    private weak var tierMapBottomSheet: TierMapBottomSheet?
     
     init(
         dependencies: TierFlowCoordinatorDependencies,
@@ -38,7 +40,9 @@ extension TierFlowCoordinator {
             showTierCategory: showTierCategory
         )
         let mapActions = TierMapViewModelActions(
-            showTierCategory: showTierCategory
+            showTierCategory: showTierCategory,
+            showMapBottomSheet: showMapBottomSheet,
+            hideMapBottomSheet: hideMapBottomSheet
         )
         let viewController = dependencies.makeTierViewController(
             listActions: listActions,
@@ -64,4 +68,17 @@ extension TierFlowCoordinator {
             currentViewController.receiveTierCategories(categories: categories)
         }
     }
+    
+    private func showMapBottomSheet() {
+        guard tierMapBottomSheet == nil else { return }
+        let viewController = dependencies.makeTierMapBottomSheet()
+        tierMapBottomSheet = viewController
+        navigationController.present(viewController, animated: true)
+    }
+    
+    private func hideMapBottomSheet() {
+        tierMapBottomSheet?.dismiss(animated: true, completion: nil)
+        tierMapBottomSheet = nil
+    }
+    
 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/TierMapViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/TierMapViewController.swift
@@ -47,6 +47,11 @@ final class TierMapViewController: UIViewController {
         setupLocationManager()
         setupBindings()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        viewModel.hideBottomSheet()
+    }
 }
 
 extension TierMapViewController {

--- a/Kustaurant/Kustaurant/Presentation/Tier/TierMapViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/TierMapViewController.swift
@@ -50,6 +50,7 @@ final class TierMapViewController: UIViewController {
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        bottomSheetDidDismiss()
         viewModel.hideBottomSheet()
     }
 }
@@ -95,5 +96,12 @@ extension TierMapViewController {
 extension TierMapViewController: TierCategoryReceivable {
     func receiveTierCategories(categories: [Category]) {
         viewModel.updateCategories(categories: categories)
+    }
+}
+
+// MARK: - TierMapBottomSheetDelegate
+extension TierMapViewController: TierMapBottomSheetDelegate {
+    func bottomSheetDidDismiss() {
+        mapHandler?.resetSelectedMarker()
     }
 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapCameraManager.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapCameraManager.swift
@@ -1,0 +1,35 @@
+//
+//  NMFMapCameraManager.swift
+//  Kustaurant
+//
+//  Created by 송우진 on 8/22/24.
+//
+
+import NMapsMap
+
+final class NMFMapCameraManager {
+    private var view: TierMapView
+    
+    // MARK: - Initialization
+    init(view: TierMapView) {
+        self.view = view
+    }
+}
+
+extension NMFMapCameraManager {
+    func cameraUpdate(_ bounds: [CGFloat?]?) {
+        guard
+            let bounds = bounds?.compactMap({ $0 }).map({ Double($0 )}),
+            bounds.count >= 4
+        else { return }
+        let visibleBounds = NMGLatLngBounds(
+            southWestLat: bounds[2],
+            southWestLng: bounds[0],
+            northEastLat: bounds[3],
+            northEastLng: bounds[1]
+        )
+        let cameraUpdate = NMFCameraUpdate(fit: visibleBounds, padding: 0)
+        cameraUpdate.animation = .fly
+        view.naverMapView.mapView.moveCamera(cameraUpdate)
+    }
+}

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapMarkerManager.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapMarkerManager.swift
@@ -49,6 +49,11 @@ extension NMFMapMarkerManager {
         markers.forEach { $0.mapView = nil }
         markers.removeAll()
     }
+    
+    func resetSelectedMarker() {
+        guard let previousMarker = selectedMarker else { return }
+        resetMarkerAppearance(previousMarker)
+    }
 }
 
 extension NMFMapMarkerManager {
@@ -76,19 +81,23 @@ extension NMFMapMarkerManager {
         return NMGLatLng(lat: lat, lng: lng)
     }
 
-    private func getMarkerIcon(named: String, size: CGSize) -> NMFOverlayImage? {
+    private func getMarkerIcon(
+        named: String,
+        size: CGSize
+    ) -> NMFOverlayImage? {
         guard let markerIcon = UIImage(named: named)?.resized(to: size) else { return nil }
         return NMFOverlayImage(image: markerIcon)
     }
 
-    private func setupMarkerTouchHandler(_ marker: NMFMarker, for restaurant: Restaurant) {
+    private func setupMarkerTouchHandler(
+        _ marker: NMFMarker,
+        for restaurant: Restaurant
+    ) {
         marker.userInfo = ["restaurant": restaurant]
         marker.touchHandler = { [weak self] _ in
             guard let restaurant = marker.userInfo["restaurant"] as? Restaurant else { return true }
             // 이전 선택된 마커의 보더 제거
-            if let previousMarker = self?.selectedMarker {
-                self?.resetMarkerAppearance(previousMarker)
-            }
+            self?.resetSelectedMarker()
             
             // 선택된 마커에 보더 추가
             self?.selectedMarker = (marker, restaurant)
@@ -153,7 +162,11 @@ extension NMFMapMarkerManager {
 
 
 private extension UIImage {
-    func resizedWithBorder(to size: CGSize, borderWidth: CGFloat, cornerRadius: CGFloat) -> UIImage? {
+    func resizedWithBorder(
+        to size: CGSize,
+        borderWidth: CGFloat,
+        cornerRadius: CGFloat
+    ) -> UIImage? {
         let imageRect = CGRect(
             origin: CGPoint(x: borderWidth, y: borderWidth),
             size: CGSize(width: size.width - 2 * borderWidth, height: size.height - 2 * borderWidth)

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapMarkerManager.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapMarkerManager.swift
@@ -1,0 +1,139 @@
+//
+//  NMFMapMarkerManager.swift
+//  Kustaurant
+//
+//  Created by 송우진 on 8/22/24.
+//
+
+import NMapsMap
+
+final class NMFMapMarkerManager {
+    private var view: TierMapView
+    private var viewModel: TierMapViewModel
+    private var markers: [NMFMarker] = []
+    
+    // MARK: - Initialization
+    init(
+        view: TierMapView,
+        viewModel: TierMapViewModel
+    ) {
+        self.view = view
+        self.viewModel = viewModel
+    }
+}
+
+extension NMFMapMarkerManager {
+    func addMarkersForRestaurants(
+        tieredRestaurants: [Restaurant?]?,
+        nonTieredRestaurants: [TierMapRestaurants.NonTieredRestaurants?]?
+    ) {
+        if let tieredRestaurants = tieredRestaurants?.compactMap({ $0 }) {
+            for restaurant in tieredRestaurants {
+                addMarker(for: restaurant, isFavorite: restaurant.isFavorite ?? false, zoom: nil)
+            }
+        }
+        
+        if let nonTieredRestaurants = nonTieredRestaurants?.compactMap({ $0 }) {
+            for nonRestaurants in nonTieredRestaurants {
+                guard let restaurants = nonRestaurants.restaurants?.compactMap({ $0 }) else { continue }
+                let zoom = nonRestaurants.zoom
+                for restaurant in restaurants {
+                    addMarker(for: restaurant, isFavorite: restaurant.isFavorite ?? false, zoom: zoom)
+                }
+            }
+        }
+    }
+    
+    func clearMarkers() {
+        markers.forEach { $0.mapView = nil }
+        markers.removeAll()
+    }
+}
+
+extension NMFMapMarkerManager {
+    private func addMarker(
+        for restaurant: Restaurant,
+        isFavorite: Bool,
+        zoom: Int?
+    ) {
+        guard let coords = getCoords(for: restaurant) else { return }
+        
+        let marker = NMFMarker(position: coords)
+        configureMarker(marker, for: restaurant, isFavorite: isFavorite, zoom: zoom)
+        setupMarkerTouchHandler(marker, for: restaurant)
+
+        marker.mapView = view.naverMapView.mapView
+        markers.append(marker)
+    }
+
+    private func getCoords(for restaurant: Restaurant) -> NMGLatLng? {
+        guard
+            let lat = Double(restaurant.y ?? ""),
+            let lng = Double(restaurant.x ?? "")
+        else { return nil }
+        
+        return NMGLatLng(lat: lat, lng: lng)
+    }
+    
+    private func configureMarker(
+        _ marker: NMFMarker,
+        for restaurant: Restaurant,
+        isFavorite: Bool,
+        zoom: Int?
+    ) {
+        var iconSize: CGSize = CGSize(width: 30, height: 30)
+        
+        if isFavorite {
+            iconSize = CGSize(width: 19, height: 19)
+            if let iconImage = getMarkerIcon(named: "icon_favorite", size: iconSize) {
+                marker.iconImage = iconImage
+                marker.zIndex = 100
+            }
+        } else {
+            configureMarkerForNonFavorite(marker, restaurant: restaurant, zoom: zoom)
+        }
+    }
+
+    private func configureMarkerForNonFavorite(
+        _ marker: NMFMarker,
+        restaurant: Restaurant,
+        zoom: Int?
+    ) {
+        if let zoom = zoom {
+            marker.isMinZoomInclusive = true
+            marker.minZoom = Double(zoom)
+        }
+
+        if let tier = restaurant.mainTier {
+            var iconSize = CGSize(width: 30, height: 30)
+            if tier == .unowned {
+                iconSize = CGSize(width: 12, height: 16)
+            }
+            if let iconImage = getMarkerIcon(named: restaurant.mainTier?.iconImageName ?? "", size: iconSize) {
+                marker.iconImage = iconImage
+                marker.zIndex = tier.zIndex
+            }
+        }
+    }
+
+    private func getMarkerIcon(
+        named: String,
+        size: CGSize
+    ) -> NMFOverlayImage? {
+        guard let markerIcon = UIImage(named: named)?.resized(to: size) else { return nil }
+        return NMFOverlayImage(image: markerIcon)
+    }
+
+    private func setupMarkerTouchHandler(
+        _ marker: NMFMarker,
+        for restaurant: Restaurant
+    ) {
+        marker.userInfo = ["restaurant": restaurant]
+        marker.touchHandler = { [weak self] _ in
+            if let restaurant = marker.userInfo["restaurant"] as? Restaurant {
+                self?.viewModel.didTapMarker(restaurant: restaurant)
+            }
+            return true
+        }
+    }
+}

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapPolygonManager.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapPolygonManager.swift
@@ -1,0 +1,85 @@
+//
+//  NMFMapPolygonManager.swift
+//  Kustaurant
+//
+//  Created by 송우진 on 8/22/24.
+//
+
+import NMapsMap
+
+final class NMFMapPolygonManager {
+    enum Polygon {
+        case solid, dashed
+    }
+    
+    private var view: TierMapView
+    
+    private var polygons: [NMFPolygonOverlay] = []
+    private var polylines: [NMFPolylineOverlay] = []
+    
+    // MARK: - Initialization
+    init(view: TierMapView) {
+        self.view = view
+    }
+}
+
+extension NMFMapPolygonManager {
+    func addPolygonOverlay(
+        type: Polygon,
+        _ polygonCoordsList: [[Coords?]?]?
+    ) {
+        guard let validCoordsList = getValidCoordsList(from: polygonCoordsList) else { return }
+
+        for coords in validCoordsList {
+            let nmgLatLngs = coords.map { $0.nmgLatLng }
+            addPolygon(type: type, nmgLatLngs: nmgLatLngs)
+        }
+    }
+    
+    func clearPolygons() {
+        polygons.forEach { $0.mapView = nil }
+        polygons.removeAll()
+        
+        polylines.forEach { $0.mapView = nil }
+        polylines.removeAll()
+    }
+}
+
+extension NMFMapPolygonManager {
+    // 유효한 좌표 리스트 필터링
+    private func getValidCoordsList(from polygonCoordsList: [[Coords?]?]?) -> [[Coords]]? {
+        polygonCoordsList?.compactMap { coordsList in
+            coordsList?.compactMap { $0 }
+        }.filter { !$0.isEmpty }
+    }
+
+    private func addPolygon(
+        type: Polygon,
+        nmgLatLngs: [NMGLatLng]
+    ) {
+        guard let polygonOverlay = NMFPolygonOverlay(nmgLatLngs) else { return }
+        polygonOverlay.fillColor = (type == .solid) ? .mapSolidBackground : .mapDashedBackground
+        switch type {
+        case .solid:
+            polygonOverlay.outlineColor = .mapOutline
+            polygonOverlay.outlineWidth = 2
+        case .dashed:
+            addDashedPolylineOverlay(coords: nmgLatLngs)
+        }
+        polygonOverlay.mapView = view.naverMapView.mapView
+        polygons.append(polygonOverlay)
+    }
+    
+    private func addDashedPolylineOverlay(coords: [NMGLatLng]) {
+        let polylineOverlay = NMFPolylineOverlay(coords + [coords.first!]) // 닫힌 다각형
+        polylineOverlay?.pattern = [5, 5]
+        polylineOverlay?.color = .mapOutline
+        polylineOverlay?.capType = .butt
+        polylineOverlay?.width = 2
+        polylineOverlay?.mapView = view.naverMapView.mapView
+        
+        if let overlay = polylineOverlay {
+            polylines.append(overlay)
+        }
+    }
+}

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
@@ -121,9 +121,8 @@ extension NMFMapViewHandler {
         
         // 마커 클릭 이벤트 처리
         marker.touchHandler = { [weak self] _ in
-            if let restaurantInfo = marker.userInfo["restaurant"] as? Restaurant {
-                print("\(restaurantInfo.restaurantName ?? "unknown")")
-                self?.viewModel.didTapMarker()
+            if let restaurant = marker.userInfo["restaurant"] as? Restaurant {
+                self?.viewModel.didTapMarker(restaurant: restaurant)
             }
             return true
         }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
@@ -116,6 +116,18 @@ extension NMFMapViewHandler {
                 marker.zIndex = tier.zIndex
             }
         }
+        
+        marker.userInfo = ["restaurant": restaurant]
+        
+        // 마커 클릭 이벤트 처리
+        marker.touchHandler = { _ in
+            if let restaurantInfo = marker.userInfo["restaurant"] as? Restaurant {
+                print("\(restaurantInfo.restaurantName ?? "unknown")")
+                
+            }
+            return true
+        }
+
         marker.mapView = view.naverMapView.mapView
         
         markers.append(marker)

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
@@ -120,10 +120,10 @@ extension NMFMapViewHandler {
         marker.userInfo = ["restaurant": restaurant]
         
         // 마커 클릭 이벤트 처리
-        marker.touchHandler = { _ in
+        marker.touchHandler = { [weak self] _ in
             if let restaurantInfo = marker.userInfo["restaurant"] as? Restaurant {
                 print("\(restaurantInfo.restaurantName ?? "unknown")")
-                
+                self?.viewModel.didTapMarker()
             }
             return true
         }
@@ -217,6 +217,7 @@ extension NMFMapViewHandler: NMFMapViewTouchDelegate {
         #if DEBUG
         print("\(latlng.lat), \(latlng.lng)")
         #endif
+        viewModel.didTapMap()
     }
     
     /// 지도 심벌이 탭되면 호출되는 콜백 메서드.
@@ -231,6 +232,7 @@ extension NMFMapViewHandler: NMFMapViewTouchDelegate {
         #if DEBUG
         print(symbol.caption!)
         #endif
+        viewModel.didTapMap()
         return true
     }
 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
@@ -14,6 +14,7 @@ final class NMFMapViewHandler: NSObject {
     
     private var markerManager: NMFMapMarkerManager
     private var polygonManager: NMFMapPolygonManager
+    private var cameraManager: NMFMapCameraManager
     
     // MARK: - Initialization
     init(
@@ -24,6 +25,7 @@ final class NMFMapViewHandler: NSObject {
         self.viewModel = viewModel
         markerManager = NMFMapMarkerManager(view: view, viewModel: viewModel)
         polygonManager = NMFMapPolygonManager(view: view)
+        cameraManager = NMFMapCameraManager(view: view)
         super.init()
         view.naverMapView.mapView.touchDelegate = self
     }
@@ -33,8 +35,7 @@ extension NMFMapViewHandler {
     func updateMap(_ data: TierMapRestaurants?) {
         guard let mapData = data else { return }
         clearMap()
-        cameraUpdate(mapData.visibleBounds)
-
+        cameraManager.cameraUpdate(mapData.visibleBounds)
         polygonManager.addPolygonOverlay(type: .solid, mapData.solidPolygonCoordsList)
         polygonManager.addPolygonOverlay(type: .dashed, mapData.dashedPolygonCoordsList)
         markerManager.addMarkersForRestaurants(
@@ -42,28 +43,12 @@ extension NMFMapViewHandler {
             nonTieredRestaurants: mapData.nonTieredRestaurants
         )
     }
-    
+}
+
+extension NMFMapViewHandler {
     private func clearMap() {
         markerManager.clearMarkers()
         polygonManager.clearPolygons()
-    }
-
-
-    // MARK: 카메라
-    private func cameraUpdate(_ bounds: [CGFloat?]?) {
-        guard
-            let bounds = bounds?.compactMap({ $0 }).map({ Double($0 )}),
-            bounds.count >= 4
-        else { return }
-        let visibleBounds = NMGLatLngBounds(
-            southWestLat: bounds[2],
-            southWestLng: bounds[0],
-            northEastLat: bounds[3],
-            northEastLng: bounds[1]
-        )
-        let cameraUpdate = NMFCameraUpdate(fit: visibleBounds, padding: 0)
-        cameraUpdate.animation = .fly
-        view.naverMapView.mapView.moveCamera(cameraUpdate)
     }
 }
 

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/NMFMapViewHandler.swift
@@ -43,6 +43,10 @@ extension NMFMapViewHandler {
             nonTieredRestaurants: mapData.nonTieredRestaurants
         )
     }
+    
+    func resetSelectedMarker() {
+        markerManager.resetSelectedMarker()
+    }
 }
 
 extension NMFMapViewHandler {
@@ -71,6 +75,7 @@ extension NMFMapViewHandler: NMFMapViewTouchDelegate {
         #if DEBUG
         print("\(latlng.lat), \(latlng.lng)")
         #endif
+        resetSelectedMarker()
         viewModel.didTapMap()
     }
     
@@ -86,6 +91,7 @@ extension NMFMapViewHandler: NMFMapViewTouchDelegate {
         #if DEBUG
         print(symbol.caption!)
         #endif
+        resetSelectedMarker()
         viewModel.didTapMap()
         return true
     }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
@@ -24,7 +24,7 @@ final class TierMapBottomSheet: UIViewController {
 extension TierMapBottomSheet {
     private func configurePageSheet() {
         modalPresentationStyle = .pageSheet
-        isModalInPresentation = true
+        isModalInPresentation = false
         if let sheet = sheetPresentationController {
             let detentIdentifier = UISheetPresentationController.Detent.Identifier("customDetent")
             let detent = UISheetPresentationController.Detent.custom(identifier: detentIdentifier) { _ in 139 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
@@ -8,13 +8,16 @@
 import UIKit
 
 final class TierMapBottomSheet: UIViewController {
-    private var restaurant: Restaurant?
+    private let sheetView: TierMapBottomSheetView = TierMapBottomSheetView()
     
     // MARK: - Life Cycle
+    override func loadView() {
+        view = sheetView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configurePageSheet()
-        view.backgroundColor = .mainGreen
     }
 }
 
@@ -32,13 +35,6 @@ extension TierMapBottomSheet {
     }
     
     func configure(with restaurant: Restaurant) {
-        self.restaurant = restaurant
-        updateUI()
-    }
-    
-    private func updateUI() {
-        guard let restaurant = restaurant else { return }
-        print("Restaurant name: \(restaurant.restaurantName ?? "")")
-        view.backgroundColor = .systemPink
+        sheetView.update(restaurant)
     }
 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
@@ -7,7 +7,12 @@
 
 import UIKit
 
+protocol TierMapBottomSheetDelegate: AnyObject {
+    func bottomSheetDidDismiss()
+}
+
 final class TierMapBottomSheet: UIViewController {
+    weak var delegate: TierMapBottomSheetDelegate?
     private let sheetView: TierMapBottomSheetView = TierMapBottomSheetView()
     
     // MARK: - Life Cycle
@@ -31,10 +36,17 @@ extension TierMapBottomSheet {
             sheet.detents = [detent]
             sheet.largestUndimmedDetentIdentifier = .init(detentIdentifier)
             sheet.prefersGrabberVisible = true
+            sheet.delegate = self
         }
     }
     
     func configure(with restaurant: Restaurant) {
         sheetView.update(restaurant)
+    }
+}
+
+extension TierMapBottomSheet: UISheetPresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        delegate?.bottomSheetDidDismiss()
     }
 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
@@ -1,0 +1,33 @@
+//
+//  TierMapBottomSheet.swift
+//  Kustaurant
+//
+//  Created by 송우진 on 8/21/24.
+//
+
+import UIKit
+
+final class TierMapBottomSheet: UIViewController {
+    private var restaurant: Restaurant?
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configurePageSheet()
+        view.backgroundColor = .mainGreen
+    }
+}
+
+extension TierMapBottomSheet {
+    private func configurePageSheet() {
+        modalPresentationStyle = .pageSheet
+        isModalInPresentation = true
+        if let sheet = sheetPresentationController {
+            let detentIdentifier = UISheetPresentationController.Detent.Identifier("customDetent")
+            let detent = UISheetPresentationController.Detent.custom(identifier: detentIdentifier) { _ in 139 }
+            sheet.detents = [detent]
+            sheet.largestUndimmedDetentIdentifier = .init(detentIdentifier)
+            sheet.prefersGrabberVisible = true
+        }
+    }
+}

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheet.swift
@@ -30,4 +30,15 @@ extension TierMapBottomSheet {
             sheet.prefersGrabberVisible = true
         }
     }
+    
+    func configure(with restaurant: Restaurant) {
+        self.restaurant = restaurant
+        updateUI()
+    }
+    
+    private func updateUI() {
+        guard let restaurant = restaurant else { return }
+        print("Restaurant name: \(restaurant.restaurantName ?? "")")
+        view.backgroundColor = .systemPink
+    }
 }

--- a/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheetView.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/View/TierMap/TierMapBottomSheetView.swift
@@ -1,0 +1,144 @@
+//
+//  TierMapBottomSheetView.swift
+//  Kustaurant
+//
+//  Created by 송우진 on 8/22/24.
+//
+
+import UIKit
+
+final class TierMapBottomSheetView: UIView {
+    private var restaurant: Restaurant?
+    private let imageView = UIImageView()
+    private var evaluatedImageView = UIImageView()
+    private var favoriteImageView = UIImageView()
+    private let iconStackView = UIStackView()
+    private var tierLabel = UILabel()
+    private let nameLabel = UILabel()
+    private let infoLabel = UILabel()
+    private let partnershipLabel = UILabel()
+    
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TierMapBottomSheetView {
+    func update(_ restaurant: Restaurant) {
+        self.restaurant = restaurant
+        loadImage()
+        updateIcons()
+        updateTier()
+        nameLabel.text = restaurant.restaurantName ?? ""
+        updateInfo()
+        partnershipLabel.text = restaurant.partnershipInfo ?? "제휴 해당 사항 없음"
+    }
+}
+
+extension TierMapBottomSheetView {
+    private func setup() {
+        backgroundColor = .white
+        addSubview(imageView, autoLayout: [.top(21), .leading(19), .width(73), .height(73)])
+        iconStackView.addArrangedSubview(favoriteImageView)
+        iconStackView.addArrangedSubview(evaluatedImageView)
+        addSubview(iconStackView, autoLayout: [.bottomEqual(to: imageView, constant: 0), .leadingEqual(to: imageView, constant: 0)])
+        addSubview(tierLabel, autoLayout: [.top(21), .trailing(25), .width(30), .height(30)])
+        addSubview(nameLabel, autoLayout: [.top(23), .leadingNext(to: imageView, constant: 23), .trailingNext(to: tierLabel, constant: 20)])
+        addSubview(infoLabel, autoLayout: [.topNext(to: nameLabel, constant: 8.5), .leadingNext(to: imageView, constant: 23), .trailingNext(to: tierLabel, constant: 20)])
+        addSubview(partnershipLabel, autoLayout: [.topNext(to: infoLabel, constant: 10), .leadingNext(to: imageView, constant: 23), .trailingNext(to: tierLabel, constant: 20)])
+        
+        configureImageView()
+        configureStatusImageView()
+        configureTierLabel()
+        configureNameLabel()
+        configureInfoLabel()
+        configurePartnershipLabel()
+    }
+    
+    private func configureImageView() {
+        imageView.layer.cornerRadius = 11
+        imageView.clipsToBounds = true
+    }
+    
+    private func configureStatusImageView() {
+        favoriteImageView.image = UIImage(named: "icon_favorite")
+        evaluatedImageView.image = UIImage(named: "icon_check")
+        favoriteImageView.autolayout([.width(19), .height(19)])
+        evaluatedImageView.autolayout([.width(19), .height(19)])
+    }
+    
+    private func configureTierLabel() {
+        tierLabel.font = .Pretendard.bold23
+        tierLabel.textAlignment = .center
+        tierLabel.textColor = .white
+        tierLabel.layer.cornerRadius = 8
+        tierLabel.clipsToBounds = true
+    }
+    
+    private func configureNameLabel() {
+        nameLabel.font = .Pretendard.semiBold16
+        nameLabel.textColor = .textBlack
+    }
+    
+    private func configureInfoLabel() {
+        infoLabel.font = .Pretendard.regular12
+        infoLabel.textColor = .textDarkGray
+    }
+    
+    private func configurePartnershipLabel() {
+        partnershipLabel.font = .Pretendard.regular10
+        partnershipLabel.textColor = .gray300
+    }
+    
+    private func updateInfo() {
+        guard let restaurant = restaurant else { return }
+        let situationList = restaurant.situationList?.compactMap({ $0 }).joined(separator: ", ")
+        infoLabel.text = [restaurant.restaurantCuisine, restaurant.restaurantPosition, situationList].compactMap({ $0 }).joined(separator: " ㅣ ")
+    }
+    
+    private func updateTier() {
+        guard let tier = restaurant?.mainTier else { return }
+        tierLabel.text = "\(tier.rawValue)"
+        tierLabel.backgroundColor = tier.backgroundColor()
+    }
+    
+    private func updateIcons() {
+        guard let restaurant = restaurant else { return }
+        iconStackView.arrangedSubviews.forEach { view in
+            iconStackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        
+        let isFavorite = [true, false].randomElement()!
+        let isEvaluated = restaurant.isEvaluated ?? false
+
+        if isFavorite {
+            iconStackView.addArrangedSubview(favoriteImageView)
+        }
+        if isEvaluated {
+            iconStackView.addArrangedSubview(evaluatedImageView)
+        }
+    }
+    
+    private func loadImage() {
+        guard let url = URL(string: restaurant?.restaurantImgUrl ?? "") else { return }
+        ImageCacheManager.shared.loadImage(
+            from: url,
+            targetWidth: 73,
+            defaultImage: UIImage(named: "img_dummy")
+        ) { [weak self] image in
+            Task {
+                await MainActor.run {
+                    self?.imageView.image = image
+                }
+            }
+        }
+    }
+}

--- a/Kustaurant/Kustaurant/Presentation/Tier/ViewModel/TierMapViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/ViewModel/TierMapViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct TierMapViewModelActions {
     let showTierCategory: ([Category]) -> Void
-    let showMapBottomSheet: () -> Void
+    let showMapBottomSheet: (Restaurant) -> Void
     let hideMapBottomSheet: () -> Void
 }
 
@@ -17,7 +17,7 @@ protocol TierMapViewModelInput {
     func fetchTierMap()
     func categoryButtonTapped()
     func updateCategories(categories: [Category])
-    func didTapMarker()
+    func didTapMarker(restaurant: Restaurant)
     func didTapMap()
     func hideBottomSheet()
 }
@@ -81,10 +81,10 @@ extension DefaultTierMapViewModel {
         self.categories = categories
     }
     
-    func didTapMarker() {
+    func didTapMarker(restaurant: Restaurant) {
         Task {
             await MainActor.run {
-                self.actions.showMapBottomSheet()
+                self.actions.showMapBottomSheet(restaurant)
             }
         }
     }

--- a/Kustaurant/Kustaurant/Presentation/Tier/ViewModel/TierMapViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/Tier/ViewModel/TierMapViewModel.swift
@@ -9,12 +9,17 @@ import Foundation
 
 struct TierMapViewModelActions {
     let showTierCategory: ([Category]) -> Void
+    let showMapBottomSheet: () -> Void
+    let hideMapBottomSheet: () -> Void
 }
 
 protocol TierMapViewModelInput {
     func fetchTierMap()
     func categoryButtonTapped()
     func updateCategories(categories: [Category])
+    func didTapMarker()
+    func didTapMap()
+    func hideBottomSheet()
 }
 
 protocol TierMapViewModelOutput {
@@ -74,5 +79,25 @@ extension DefaultTierMapViewModel {
     
     func updateCategories(categories: [Category]) {
         self.categories = categories
+    }
+    
+    func didTapMarker() {
+        Task {
+            await MainActor.run {
+                self.actions.showMapBottomSheet()
+            }
+        }
+    }
+    
+    func didTapMap() {
+        hideBottomSheet()
+    }
+    
+    func hideBottomSheet() {
+        Task {
+            await MainActor.run {
+                self.actions.hideMapBottomSheet()
+            }
+        }
     }
 }

--- a/Kustaurant/Kustaurant/Utils/Extensions/UIFont+Pretendard.swift
+++ b/Kustaurant/Kustaurant/Utils/Extensions/UIFont+Pretendard.swift
@@ -10,6 +10,7 @@ import UIKit
 extension UIFont {
     
     enum Pretendard {
+        static let bold23 = UIFont(name: "Pretendard-Bold", size: 23)!
         static let bold20 = UIFont(name: "Pretendard-Bold", size: 20)!
         static let bold16 = UIFont(name: "Pretendard-Bold", size: 16)!
         static let bold13 = UIFont(name: "Pretendard-Bold", size: 13)!


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
마커를 클릭하면 바텀 시트가 열리는 기능을 구현했습니다.
- 마커가 아닌 심볼이나 지도를 클릭하면 시트가 닫히고 마커 초기화
- 지도 화면을 떠나면 시트가 닫히고 마커 초기화
- map handler class 리팩토링
   -> 클래스 크기를 줄이기 위해 로직 분리


<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
