### PR TITLE
app store reject, guideline 5.1.1 (로그인 관련)

### DIFF
--- a/Kustaurant/Kustaurant/Domain/UseCases/AuthUseCases.swift
+++ b/Kustaurant/Kustaurant/Domain/UseCases/AuthUseCases.swift
@@ -14,6 +14,7 @@ protocol AuthUseCases {
     func logout()
     func skipLogin()
     func deleteAccount() async
+    func isLogin() async -> Bool
 }
 
 final class DefaultAuthUseCases {
@@ -32,6 +33,10 @@ final class DefaultAuthUseCases {
 }
 
 extension DefaultAuthUseCases: AuthUseCases {
+    
+    func isLogin() async -> Bool {
+        await authReposiory.verifyToken()
+    }
     
     func naverLogin() -> AnyPublisher<UserCredentials, NetworkError> {
         naverLoginService.attemptLogin()

--- a/Kustaurant/Kustaurant/Domain/UseCases/MyPageUseCases.swift
+++ b/Kustaurant/Kustaurant/Domain/UseCases/MyPageUseCases.swift
@@ -15,6 +15,7 @@ protocol MyPageUseCases {
     func getFavoriteRestaurants() async -> Result<[FavoriteRestaurant], NetworkError>
     func getEvaluatedRestaurants() async -> Result<[EvaluatedRestaurant], NetworkError>
     func getNoticeList() async -> Result<[Notice], NetworkError> 
+    func isLogin() -> Bool
 }
 
 final class DefaultMyPageUseCases {
@@ -27,6 +28,12 @@ final class DefaultMyPageUseCases {
 }
     
 extension DefaultMyPageUseCases: MyPageUseCases {
+    func isLogin() -> Bool {
+        guard let _: UserCredentials = KeychainStorage.shared.getValue(forKey: KeychainKey.userCredentials) else {
+            return false
+        }
+        return true
+    }
     func sendFeedback(_ comments: String) async -> Result<Void, NetworkError> {
         return await myPageRepository.sendFeedback(comments)
     }

--- a/Kustaurant/Kustaurant/Domain/UseCases/MyPageUseCases.swift
+++ b/Kustaurant/Kustaurant/Domain/UseCases/MyPageUseCases.swift
@@ -15,7 +15,6 @@ protocol MyPageUseCases {
     func getFavoriteRestaurants() async -> Result<[FavoriteRestaurant], NetworkError>
     func getEvaluatedRestaurants() async -> Result<[EvaluatedRestaurant], NetworkError>
     func getNoticeList() async -> Result<[Notice], NetworkError> 
-    func isLogin() -> Bool
 }
 
 final class DefaultMyPageUseCases {
@@ -28,12 +27,6 @@ final class DefaultMyPageUseCases {
 }
     
 extension DefaultMyPageUseCases: MyPageUseCases {
-    func isLogin() -> Bool {
-        guard let _: UserCredentials = KeychainStorage.shared.getValue(forKey: KeychainKey.userCredentials) else {
-            return false
-        }
-        return true
-    }
     func sendFeedback(_ comments: String) async -> Result<Void, NetworkError> {
         return await myPageRepository.sendFeedback(comments)
     }

--- a/Kustaurant/Kustaurant/Presentation/MyPage/MyPageViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/MyPageViewController.swift
@@ -64,6 +64,13 @@ extension MyPageViewController {
             }
         }
         .store(in: &cancellables)
+        
+        viewModel.tableViewSectionsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.myPageTableViewHandler?.reloadData()
+            }
+            .store(in: &cancellables)
     }
     
     private func bindUserProfileView() {

--- a/Kustaurant/Kustaurant/Presentation/MyPage/MyPageViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/MyPageViewController.swift
@@ -105,7 +105,7 @@ extension MyPageViewController {
         alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { [weak self] _ in
             self?.viewModel.dismissAlert()
         }))
-        alert.addAction(UIAlertAction(title: "확인", style: .destructive, handler: { [weak self] _ in
+        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { [weak self] _ in
             self?.viewModel.alertPayload.onConfirm?()
         }))
         present(alert, animated: true, completion: nil)

--- a/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewHandler.swift
@@ -83,7 +83,6 @@ extension MyPageTableViewHandler {
 extension MyPageTableViewHandler: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if viewModel.isLoggedIn == .notLoggedIn { return }
         let item = viewModel.tableViewSections[indexPath.section].items[indexPath.row]
         switch item.type {
         case .savedRestaurants:

--- a/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewHandler.swift
@@ -43,14 +43,12 @@ extension MyPageTableViewHandler {
             headerView.profileButton.setTitle("로그인하고 시작하기", for: .normal)
         }
         
-        if loginStatus == .loggedIn {
-            headerView.onTapMyEvaluation = { [weak self] in
-                self?.viewModel.didTapEvaluatedRestaurants()
-            }
-            
-            headerView.onTapSavedRestaurants = { [weak self] in
-                self?.viewModel.didTapSavedRestaurants()
-            }
+        headerView.onTapMyEvaluation = { [weak self] in
+            self?.viewModel.didTapEvaluatedRestaurants()
+        }
+        
+        headerView.onTapSavedRestaurants = { [weak self] in
+            self?.viewModel.didTapSavedRestaurants()
         }
         
         for sectionIndex in 0..<viewModel.tableViewSections.count {

--- a/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewHandler.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewHandler.swift
@@ -31,6 +31,10 @@ extension MyPageTableViewHandler {
         view.tableView.contentInsetAdjustmentBehavior = .never
     }
     
+    func reloadData() {
+        view.tableView.reloadData()
+    }
+    
     func updateUI(by loginStatus: LoginStatus) {
         headerView.profileImageView.image = UIImage(named: loginStatus.profileImageName)
         headerView.profileButton.configuration = loginStatus.profileButtonConfiguration

--- a/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewSection.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/View/MyPage/MyPageTableViewSection.swift
@@ -25,6 +25,6 @@ struct MyPageTableViewItem {
 
 struct MyPageTableViewSection {
     let id: String
-    let items: [MyPageTableViewItem]
+    var items: [MyPageTableViewItem]
     let footerHeight: Int
 }

--- a/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -149,6 +149,11 @@ extension DefaultMyPageViewModel {
             }
         }
     }
+    
+    private func showAlertLogin() {
+        alertPayload = AlertPayload(title: "로그인 후 사용 가능합니다.", subtitle: "로그인 하시겠습니까?", onConfirm: didTapLoginAndStartButton)
+        showAlert = true
+    }
 }
 
 // Button Actions
@@ -179,10 +184,18 @@ extension DefaultMyPageViewModel: MyPageViewModel {
     }
     
     func didTapSavedRestaurants() {
+        guard isLogin() == true else {
+            showAlertLogin()
+            return
+        }
         actions.showSavedRestaurants()
     }
     
     func didTapEvaluatedRestaurants() {
+        guard isLogin() == true else {
+            showAlertLogin()
+            return
+        }
         actions.showEvaluatedRestaurants()
     }
     

--- a/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -43,6 +43,7 @@ protocol MyPageViewModelOutput {
     var showAlert: Bool { get }
     var showAlertPublisher: Published<Bool>.Publisher { get }
     var alertPayload: AlertPayload { get }
+    var tableViewSectionsPublisher: Published<[MyPageTableViewSection]>.Publisher { get }
 }
 
 typealias MyPageViewModel = MyPageViewModelInput & MyPageViewModelOutput
@@ -59,34 +60,8 @@ final class DefaultMyPageViewModel {
     @Published var showAlert: Bool = false
     var showAlertPublisher: Published<Bool>.Publisher { $showAlert }
     @Published var alertPayload: AlertPayload = AlertPayload.empty()
-    
-    var tableViewSections: [MyPageTableViewSection] = [
-        MyPageTableViewSection(
-            id: "activity",
-            items: [
-                MyPageTableViewItem(type: .savedRestaurants, title: "저장된 맛집", iconNamePrefix: "icon_saved_restaurants")
-            ],
-            footerHeight: 20
-        ),
-        MyPageTableViewSection(
-            id: "service",
-            items: [
-                MyPageTableViewItem(type: .termsOfService, title: "이용약관", iconNamePrefix: "icon_terms_of_service"),
-                MyPageTableViewItem(type: .sendFeedback, title: "의견 보내기", iconNamePrefix: "icon_send_feedback"),
-                MyPageTableViewItem(type: .notice, title: "공지사항", iconNamePrefix: "icon_notice_board"),
-                MyPageTableViewItem(type: .privacyPolicy, title: "개인정보처리방침", iconNamePrefix: "icon_privacy_policy")
-            ],
-            footerHeight: 20
-        ),
-        MyPageTableViewSection(
-            id: "user",
-            items: [
-                MyPageTableViewItem(type: .logout, title: "로그아웃", iconNamePrefix: "icon_logout"),
-                MyPageTableViewItem(type: .deleteAccount, title: "회원탈퇴", iconNamePrefix: "icon_delete_account")
-            ],
-            footerHeight: 100
-        )
-    ]
+    @Published var tableViewSections: [MyPageTableViewSection] = []
+    var tableViewSectionsPublisher: Published<[MyPageTableViewSection]>.Publisher { $tableViewSections }
     
     init(actions: MyPageViewModelActions, authUseCases: AuthUseCases, myPageUseCases: MyPageUseCases) {
         self.actions = actions
@@ -97,15 +72,63 @@ final class DefaultMyPageViewModel {
 
 extension DefaultMyPageViewModel {
     
+    func isLogin() -> Bool {
+        myPageUseCases.isLogin()
+    }
+    func updateTableViewSections(isLoggedIn: LoginStatus) {
+        var sections: [MyPageTableViewSection] = [
+            MyPageTableViewSection(
+                id: "activity",
+                items: [
+                    MyPageTableViewItem(type: .savedRestaurants, title: "저장된 맛집", iconNamePrefix: "icon_saved_restaurants")
+                ],
+                footerHeight: 20
+            ),
+            MyPageTableViewSection(
+                id: "service",
+                items: [
+                    MyPageTableViewItem(type: .termsOfService, title: "이용약관", iconNamePrefix: "icon_terms_of_service"),
+                    MyPageTableViewItem(type: .notice, title: "공지사항", iconNamePrefix: "icon_notice_board"),
+                    MyPageTableViewItem(type: .privacyPolicy, title: "개인정보처리방침", iconNamePrefix: "icon_privacy_policy")
+                ],
+                footerHeight: 20
+            )
+        ]
+        
+        if isLoggedIn == .loggedIn {
+            sections[1].items.append(MyPageTableViewItem(type: .sendFeedback, title: "의견 보내기", iconNamePrefix: "icon_send_feedback"))
+            sections.append(
+                MyPageTableViewSection(
+                    id: "user",
+                    items: [
+                        MyPageTableViewItem(type: .logout, title: "로그아웃", iconNamePrefix: "icon_logout"),
+                        MyPageTableViewItem(type: .deleteAccount, title: "회원탈퇴", iconNamePrefix: "icon_delete_account")
+                    ],
+                    footerHeight: 100
+                )
+            )
+        }
+        
+        tableViewSections = sections
+    }
+    
     func getUserSavedRestaurants() {
+        guard isLogin() == true else {
+            isLoggedIn = .notLoggedIn
+            updateTableViewSections(isLoggedIn: .notLoggedIn)
+            return
+        }
         Task {
             let userSavedRestaurants = await myPageUseCases.getSavedRestaurantsCount()
             switch userSavedRestaurants {
             case .success(let savedRestaurants):
                 isLoggedIn = .loggedIn
                 self.userSavedRestaurants = savedRestaurants
+                updateTableViewSections(isLoggedIn: .loggedIn)
+                
             case .failure:
                 isLoggedIn = .notLoggedIn
+                updateTableViewSections(isLoggedIn: .notLoggedIn)
             }
         }
     }

--- a/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -78,13 +78,6 @@ extension DefaultMyPageViewModel {
     func updateTableViewSections(isLoggedIn: LoginStatus) {
         var sections: [MyPageTableViewSection] = [
             MyPageTableViewSection(
-                id: "activity",
-                items: [
-                    MyPageTableViewItem(type: .savedRestaurants, title: "저장된 맛집", iconNamePrefix: "icon_saved_restaurants")
-                ],
-                footerHeight: 20
-            ),
-            MyPageTableViewSection(
                 id: "service",
                 items: [
                     MyPageTableViewItem(type: .termsOfService, title: "이용약관", iconNamePrefix: "icon_terms_of_service"),
@@ -96,6 +89,14 @@ extension DefaultMyPageViewModel {
         ]
         
         if isLoggedIn == .loggedIn {
+            sections.insert(
+                MyPageTableViewSection(
+                    id: "activity",
+                    items: [
+                        MyPageTableViewItem(type: .savedRestaurants, title: "저장된 맛집", iconNamePrefix: "icon_saved_restaurants")
+                    ],
+                    footerHeight: 20
+                ), at: 0)
             sections[1].items.append(MyPageTableViewItem(type: .sendFeedback, title: "의견 보내기", iconNamePrefix: "icon_send_feedback"))
             sections.append(
                 MyPageTableViewSection(

--- a/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -72,9 +72,10 @@ final class DefaultMyPageViewModel {
 
 extension DefaultMyPageViewModel {
     
-    func isLogin() -> Bool {
-        myPageUseCases.isLogin()
+    func isLogin() async -> Bool {
+        await authUseCases.isLogin()
     }
+    
     func updateTableViewSections(isLoggedIn: LoginStatus) {
         var sections: [MyPageTableViewSection] = [
             MyPageTableViewSection(
@@ -115,11 +116,13 @@ extension DefaultMyPageViewModel {
     }
     
     func getUserSavedRestaurants() {
-        guard isLogin() == true else {
-            updateTableViewSections(isLoggedIn: .notLoggedIn)
-            return
-        }
+        
         Task {
+            guard await isLogin() == true else {
+                updateTableViewSections(isLoggedIn: .notLoggedIn)
+                return
+            }
+            
             let userSavedRestaurants = await myPageUseCases.getSavedRestaurantsCount()
             switch userSavedRestaurants {
             case .success(let savedRestaurants):
@@ -149,9 +152,11 @@ extension DefaultMyPageViewModel {
         }
     }
     
-    private func showAlertLogin() {
-        alertPayload = AlertPayload(title: "로그인 후 사용 가능합니다.", subtitle: "로그인 하시겠습니까?", onConfirm: didTapLoginAndStartButton)
-        showAlert = true
+    private func showAlertLogin() async {
+        await MainActor.run {
+            alertPayload = AlertPayload(title: "로그인 후 사용 가능합니다.", subtitle: "로그인 하시겠습니까?", onConfirm: didTapLoginAndStartButton)
+            showAlert = true
+        }
     }
 }
 
@@ -183,19 +188,25 @@ extension DefaultMyPageViewModel: MyPageViewModel {
     }
     
     func didTapSavedRestaurants() {
-        guard isLogin() == true else {
-            showAlertLogin()
-            return
+        Task {
+            guard await isLogin() == true else {
+                await showAlertLogin()
+                return
+            }
+            actions.showSavedRestaurants()
         }
-        actions.showSavedRestaurants()
+        
     }
     
     func didTapEvaluatedRestaurants() {
-        guard isLogin() == true else {
-            showAlertLogin()
-            return
+        Task {
+            guard await isLogin() == true else {
+                await showAlertLogin()
+                return
+            }
+            actions.showEvaluatedRestaurants()
         }
-        actions.showEvaluatedRestaurants()
+        
     }
     
     func didTapSendFeedback() {

--- a/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kustaurant/Kustaurant/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -111,11 +111,11 @@ extension DefaultMyPageViewModel {
         }
         
         tableViewSections = sections
+        self.isLoggedIn = isLoggedIn
     }
     
     func getUserSavedRestaurants() {
         guard isLogin() == true else {
-            isLoggedIn = .notLoggedIn
             updateTableViewSections(isLoggedIn: .notLoggedIn)
             return
         }
@@ -123,12 +123,11 @@ extension DefaultMyPageViewModel {
             let userSavedRestaurants = await myPageUseCases.getSavedRestaurantsCount()
             switch userSavedRestaurants {
             case .success(let savedRestaurants):
-                isLoggedIn = .loggedIn
-                self.userSavedRestaurants = savedRestaurants
                 updateTableViewSections(isLoggedIn: .loggedIn)
+                self.userSavedRestaurants = savedRestaurants
+                
                 
             case .failure:
-                isLoggedIn = .notLoggedIn
                 updateTableViewSections(isLoggedIn: .notLoggedIn)
             }
         }

--- a/Kustaurant/Kustaurant/Presentation/Onboarding/LoginViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/Onboarding/LoginViewController.swift
@@ -57,10 +57,10 @@ extension LoginViewController {
         }
         .store(in: &cancellables)
         
-        loginView.socialLoginView.skipButton.tapPublisher().sink { [weak self] in
-            self?.viewModel.skipLogin()
-        }
-        .store(in: &cancellables)
+        loginView.socialLoginView.skipButton.addAction(
+            UIAction { [weak self] _ in
+                self?.viewModel.skipLogin()
+            }, for: .touchUpInside)
     }
 }
 

--- a/Kustaurant/Kustaurant/Presentation/Onboarding/OnboardingViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/Onboarding/OnboardingViewController.swift
@@ -69,10 +69,11 @@ extension OnboardingViewController {
         }
         .store(in: &cancellables)
         
-        onboardingView.socialLoginView.skipButton.tapPublisher().sink { [weak self] in
-            self?.viewModel.skipLogin()
-        }
-        .store(in: &cancellables)
+        
+        onboardingView.socialLoginView.skipButton.addAction(
+            UIAction { [weak self] _ in
+                self?.viewModel.skipLogin()
+            }, for: .touchUpInside)
     }
 }
 

--- a/Kustaurant/Kustaurant/Presentation/Onboarding/View/SocialLogin/SocialLoginView.swift
+++ b/Kustaurant/Kustaurant/Presentation/Onboarding/View/SocialLogin/SocialLoginView.swift
@@ -69,7 +69,6 @@ class SocialLoginView: UIView {
         button.setAttributedTitle(underlineAttriString1, for: .normal)
         button.titleLabel?.font = .Pretendard.regular12
         button.setTitleColor(titleColor, for: .normal)
-        button.isHidden = true
         return button
     }()
     

--- a/Kustaurant/Kustaurant/Presentation/RestaurantDetail/RestaurantDetailViewController.swift
+++ b/Kustaurant/Kustaurant/Presentation/RestaurantDetail/RestaurantDetailViewController.swift
@@ -143,12 +143,6 @@ extension RestaurantDetailViewController {
                     
                 case .loginStatus(let loginStatus):
                     self?.evaluationFloatingView.loginStatus = loginStatus
-                    self?.evaluationFloatingView.onTapEvaluateButton = { [weak self] in
-                        self?.viewModel.state = .didTapEvaluationButton
-                    }
-                    self?.evaluationFloatingView.onTapFavoriteButton = { [weak self] in
-                        self?.viewModel.state = .didTapFavoriteButton
-                    }
                     
                 case .didSuccessLikeOrDisLikeButton(let commentId, let likeCount, let dislikeCount, let likeStatus):
                     guard let self = self else { return }
@@ -197,6 +191,13 @@ extension RestaurantDetailViewController {
                 self?.viewModel.state = .didTapSendButtonInAccessory(payload: payload)
             }
             .store(in: &cancellables)
+        
+        evaluationFloatingView.onTapEvaluateButton = { [weak self] in
+            self?.viewModel.state = .didTapEvaluationButton
+        }
+        evaluationFloatingView.onTapFavoriteButton = { [weak self] in
+            self?.viewModel.state = .didTapFavoriteButton
+        }
     }
 }
 
@@ -371,9 +372,9 @@ extension RestaurantDetailViewController {
     
     private func presentAlert(payload: AlertPayload) {
         let alert = UIAlertController(title: payload.title, message: payload.subtitle, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "취소", style: .default, handler: { _ in
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { _ in
         }))
-        alert.addAction(UIAlertAction(title: "확인", style: .destructive, handler: { _ in
+        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
             payload.onConfirm?()
         }))
         present(alert, animated: true, completion: nil)

--- a/Kustaurant/Kustaurant/Presentation/RestaurantDetail/View/EvaluationFloatingView.swift
+++ b/Kustaurant/Kustaurant/Presentation/RestaurantDetail/View/EvaluationFloatingView.swift
@@ -26,7 +26,7 @@ final class EvaluationFloatingView: UIView {
     var loginStatus: LoginStatus = .notLoggedIn {
         didSet {
             evaluateButton.buttonState = loginStatus == .loggedIn ? .on : .off
-            favoriteButton.isEnabled = loginStatus == .loggedIn ? true : false
+            evaluateButton.isEnabled = true
         }
     }
     
@@ -80,7 +80,6 @@ extension EvaluationFloatingView {
     private func setupLayout() {
         containerView.backgroundColor = .white
         let window = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap { $0.windows }.first { $0.isKeyWindow }        
-        let bottomSafeAreaHeight = window?.safeAreaInsets.bottom ?? 0
         addSubview(containerView, autoLayout: [.fill(0), .height(EvaluationFloatingView.getHeight())])
         
         switch viewType {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
리젝 사유 수정
1. 로그인 화면에 건너뛰기 버튼 활성화 및 코드 수정
2. 로그인, 비로그인 마이페이지 ui 다르게 변경
3. 비로그인시 평가하기 클릭 시 로그인 유도 액션 추가

---
Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage

The app requires users to register or log in to access features that are not account based.


Apps may not require users to enter personal information to function, except when directly relevant to the core functionality of the app or required by law. For example, an e-commerce app should let users browse store offerings and other features that are not account based before being asked to register, or a restaurant app should allow users to explore the menu before placing an order. Registration must then only be required for account-specific features, such as saving items for future reference or placing an order.


Next Steps


To resolve this issue, please revise the app to let users freely access the app's features that are not account based.


Resources


See [guideline 5.1.1(v) - Account Sign-In](https://developer.apple.com/app-store/review/guidelines/#data-collection-and-storage) to learn more about requirements for apps with account-based content and features.

<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
